### PR TITLE
Add a vagrantfile for easy provisioning of Ubuntu VMs with Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,10 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt install -y docker.io
+  SHELL
+end


### PR DESCRIPTION
For my own dev sandboxes, I like to use vagrant.  This PR adds a minimal Vagrantfile that provisions an Ubuntu 18.04 vm with Docker suitable for running/developing the coding challenge.

I don't particularly care if this code his the mainline.  I'll `.git/info/exclude` my vagrant stuff if we'd collectively rather keep stuff like this out of the repo.  I thought you might be interested in seeing it anyhow, as it is part of my dev process for this project.

Feedback I'd like:
* "Ship it" or "I don't think per-dev stuff like this belongs in the repo."