### PR TITLE
Build work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ src/grav/wellknown.tar
 # python build artifacts
 MANIFEST
 dist/
+gravitational_audition*.whl
 *.egg-info
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # intermediate make targets
 wellknown-container/.image_id
 wellknown-container/.container_id
+
+# python build artifacts
+MANIFEST
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ src/grav/wellknown.tar
 # python build artifacts
 MANIFEST
 dist/
+*.egg-info
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # intermediate make targets
 wellknown-container/.image_id
 wellknown-container/.container_id
+src/grav/wellknown.tar
 
 # python build artifacts
 MANIFEST

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/grav/wellknown.tgz

--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,26 @@ help:
 	@echo "  container    create a container from the wellknown image"
 	@echo "  container-smoke   smoke test the container"
 
+PYDIR=src/grav
+
 DOCKERDIR=wellknown-container
 IMAGE_ID=$(DOCKERDIR)/.image_id
 CONTAINER_ID=$(DOCKERDIR)/.container_id
+IMAGE_TAR=$(PYDIR)/wellknown.tar
+DOCKER_SCHMUTZ=$(IMAGE_TAR) $(IMAGE_ID) $(CONTAINER_ID)
+
 
 $(IMAGE_ID):  $(DOCKERDIR)/Dockerfile $(DOCKERDIR)/loop.sh
 	docker build  --iidfile $(IMAGE_ID) $(DOCKERDIR)
+
+$(IMAGE_TAR): $(IMAGE_ID)
+	docker save --output $(IMAGE_TAR) $(shell cat $(IMAGE_ID))
 
 $(CONTAINER_ID): $(IMAGE_ID)
 	rm -f $(CONTAINER_ID)
 	docker create --cidfile $(CONTAINER_ID) $(shell cat $(IMAGE_ID))
 
-image: $(IMAGE_ID)
+image: $(IMAGE_TAR)
 
 container: $(CONTAINER_ID)
 
@@ -27,4 +35,4 @@ container-smoke: $(CONTAINER_ID)
 	docker logs $(shell cat $(CONTAINER_ID))
 
 clean:
-	rm -f $(IMAGE_ID) $(CONTAINER_ID)
+	rm -f $(DOCKER_SCHMUTZ)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean image container container-smoke prune
+.PHONY: build clean image container container-smoke prune
 
 help:
 	@echo "  image        build the wellknown docker image"
@@ -7,6 +7,12 @@ help:
 	@echo "  prune        clean up stray containers, images and references to them"
 
 PYDIR=src/grav
+DISTDIR=dist
+PYSRC=$(shell find $(PYDIR) -name '*.py')
+# TODO: make this handle versioning properly
+# if I planned on changing the version
+WHEEL=$(DISTDIR)/gravitational_audition-0.1.0-py3-none-any.whl
+PYTHON_SCHMUTZ=$(WHEEL)
 
 DOCKERDIR=wellknown-container
 IMAGE_ID=$(DOCKERDIR)/.image_id
@@ -25,6 +31,11 @@ $(CONTAINER_ID): $(IMAGE_ID)
 	rm -f $(CONTAINER_ID)
 	docker create --cidfile $(CONTAINER_ID) $(shell cat $(IMAGE_ID))
 
+$(WHEEL): $(PYSRC) $(IMAGE_TAR)
+	pip wheel --wheel-dir dist/ .
+
+build: $(WHEEL)
+
 image: $(IMAGE_TAR)
 
 container: $(CONTAINER_ID)
@@ -39,4 +50,4 @@ prune: clean
 	docker system prune -f
 
 clean:
-	rm -f $(DOCKER_SCHMUTZ)
+	rm -f $(DOCKER_SCHMUTZ) $(PYTHON_SCHMUTZ)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: clean image container container-smoke
+.PHONY: clean image container container-smoke prune
 
 help:
 	@echo "  image        build the wellknown docker image"
 	@echo "  container    create a container from the wellknown image"
 	@echo "  container-smoke   smoke test the container"
+	@echo "  prune        clean up stray containers, images and references to them"
 
 PYDIR=src/grav
 
@@ -33,6 +34,9 @@ container-smoke: $(CONTAINER_ID)
 	sleep 1
 	docker stop $(shell cat $(CONTAINER_ID))
 	docker logs $(shell cat $(CONTAINER_ID))
+
+prune: clean
+	docker system prune -f
 
 clean:
 	rm -f $(DOCKER_SCHMUTZ)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
-.PHONY: build clean image container container-smoke prune
+.PHONY: build clean image container container-smoke
 
 help:
 	@echo "  image        build the wellknown docker image"
 	@echo "  container    create a container from the wellknown image"
 	@echo "  container-smoke   smoke test the container"
-	@echo "  prune        clean up stray containers, images and references to them"
 
 PYDIR=src/grav
 DISTDIR=dist
@@ -45,9 +44,6 @@ container-smoke: $(CONTAINER_ID)
 	sleep 1
 	docker stop $(shell cat $(CONTAINER_ID))
 	docker logs $(shell cat $(CONTAINER_ID))
-
-prune: clean
-	docker system prune -f
 
 clean:
 	rm -f $(DOCKER_SCHMUTZ) $(PYTHON_SCHMUTZ)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from distutils.core import setup
+
+setup(
+    name="gravitational-audition",
+    version="0.1.0",
+    author="Walt Della",
+    author_email="walt@javins.net",
+    description="A coding audition via a docker API test case.",
+    url="https://github.com/javins/gravitational-audition",
+    packages=['grav'],
+    package_dir={'grav': 'src/grav'},
+)

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,7 @@ setup(
     description="A coding audition via a docker API test case.",
     url="https://github.com/javins/gravitational-audition",
     packages=['grav'],
-    package_dir={'grav': 'src/grav'},
+    package_dir={'': 'src'},
+    package_data={'grav': 'wellknown.tgz'},
+    include_package_data=True,
 )


### PR DESCRIPTION
This PR includes improvements to the build:
 - python packaging
 - with a tar of the wellknown container baked into the python build
 - improved cleanup of dev artifacts (i.e. `make prune` to clear out leftover images from failed test runs)

See individual commit messages for more info.

Testing Done:
```
# clean and full build

(venv) vagrant@ubuntu-bionic:/vagrant$ make clean
rm -f src/grav/wellknown.tar wellknown-container/.image_id wellknown-container/.container_id dist/gravitational_audition-0.1.0-py3-none-any.whl
(venv) vagrant@ubuntu-bionic:/vagrant$ make build
docker build  --iidfile wellknown-container/.image_id wellknown-container
Sending build context to Docker daemon  3.072kB
Step 1/3 : from alpine:3.10
 ---> 961769676411
Step 2/3 : copy loop.sh /tmp/loop.sh
 ---> Using cache
 ---> 82e4febc0d79
Step 3/3 : cmd ["sh", "/tmp/loop.sh"]
 ---> Using cache
 ---> a34690973417
Successfully built a34690973417
docker save --output src/grav/wellknown.tar sha256:a34690973417bdec5f1056a398a7bb4223f64dc05820e2c407695e9937e76340
pip wheel --wheel-dir dist/ .
Processing /vagrant
Building wheels for collected packages: gravitational-audition
  Running setup.py bdist_wheel for gravitational-audition ... done
  Stored in directory: /vagrant/dist
Successfully built gravitational-audition


# partial build with nothing changed

(venv) vagrant@ubuntu-bionic:/vagrant$ make build
make: Nothing to be done for 'build'.


# partial build with the container changed

(venv) vagrant@ubuntu-bionic:/vagrant$ touch wellknown-container/loop.sh
(venv) vagrant@ubuntu-bionic:/vagrant$ make build
docker build  --iidfile wellknown-container/.image_id wellknown-container
Sending build context to Docker daemon  3.072kB
Step 1/3 : from alpine:3.10
 ---> 961769676411
Step 2/3 : copy loop.sh /tmp/loop.sh
 ---> Using cache
 ---> 82e4febc0d79
Step 3/3 : cmd ["sh", "/tmp/loop.sh"]
 ---> Using cache
 ---> a34690973417
Successfully built a34690973417
docker save --output src/grav/wellknown.tar sha256:a34690973417bdec5f1056a398a7bb4223f64dc05820e2c407695e9937e76340
pip wheel --wheel-dir dist/ .
Processing /vagrant
Building wheels for collected packages: gravitational-audition
  Running setup.py bdist_wheel for gravitational-audition ... done
  Stored in directory: /vagrant/dist
Successfully built gravitational-audition
(venv) vagrant@ubuntu-bionic:/vagrant$ 


# pruning docker images
(venv) vagrant@ubuntu-bionic:/vagrant$ docker image list
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
<none>              <none>              a34690973417        25 minutes ago      5.58MB
alpine              3.10                961769676411        8 weeks ago         5.58MB
(venv) vagrant@ubuntu-bionic:/vagrant$ make prune
rm -f src/grav/wellknown.tar wellknown-container/.image_id wellknown-container/.container_id dist/gravitational_audition-0.1.0-py3-none-any.whl
docker system prune -f
Deleted Images:
deleted: sha256:a34690973417bdec5f1056a398a7bb4223f64dc05820e2c407695e9937e76340
deleted: sha256:82e4febc0d792bd19806f87a4475f6dfcf010da9033984ea4cad5de5edceec78
deleted: sha256:858bde05b018398fb09bbb24fd59f7531511a54a9afdbcec8eabbbfe03f65e02

Total reclaimed space: 308B
(venv) vagrant@ubuntu-bionic:/vagrant$ docker image list
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
alpine              3.10                961769676411        8 weeks ago         5.58MB
```