### PR TITLE
Add error handling, output & test harness

### DIFF
--- a/src/grav/client.py
+++ b/src/grav/client.py
@@ -23,7 +23,7 @@ class FriendlyHTTPResponse(HTTPResponse):
     I really like requests .json() method on response objects.
 
     Also, in vanilla HTTPResponse objects, once read() there is no sanctioned
-    API to get the body content a second time.  Hope you remembed it! This
+    API to get the body content a second time.  Hope you remembered it! This
     class allows accessing body content via .body, which lazy loads/caches the
     body. Doing this is important to enable failUnlessStatus displaying body
     info without having to worry about whether the test already read the body of

--- a/src/grav/client.py
+++ b/src/grav/client.py
@@ -104,6 +104,12 @@ class DockerClient:
             body = json.dumps(body)
         self.conn.request(verb, path, body=body, headers=headers)
         resp = self.conn.getresponse()
+        # Associate the request with the response to help with logging
+        # & error messages.  This is not a great pattern, but doing it
+        # a better way (e.g. request is an arg to FriendlyHttpResponse, and
+        # a proper adapter) is more refactoring than I want to undertake.
+        # -- wdella 201
+        resp.request = verb + ' ' + path  # to assist with logging
         return resp
 
     # make sure not to  leak connections, close when the client falls out of scope

--- a/src/grav/client.py
+++ b/src/grav/client.py
@@ -78,8 +78,8 @@ class SocketHTTPConnection(HTTPConnection):
         sock.connect(self.socket_path)
         self.sock = sock
 
-    def response_class(self, sock, *args, **kwargs):
-        return FriendlyHTTPResponse(sock, *args, **kwargs)
+    def response_class(self, *args, **kwargs):
+        return FriendlyHTTPResponse(*args, **kwargs)
 
 
 class DockerClient:

--- a/src/grav/harness.py
+++ b/src/grav/harness.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+
+
+class HttpStatusError(Exception):
+    pass
+
+
+def assert_status(response, expected):
+    # Not a unittest assert, as this is used in setup & teardown
+    # future work: validate argument types
+    if response.status != expected:
+        # future work: consider the case body isn't text or
+        # should be truncated... also prettyprinting
+        msg = "{} returned http status {} instead of expected {}.\nBody:\n{}"\
+            .format(response.request, response.status, expected, response.body)
+        raise HttpStatusError(msg)
+
+
+class DockerApiTest(TestCase):
+    """
+    Abstract base test for Docker api tests.
+    """
+
+    def assertStatus(self, response, expected):
+        # camelCased for consistency with unittest assert/fail methods
+        try:
+            assert_status(response, expected)
+        except HttpStatusError as e:
+            raise self.failureException(e) from None

--- a/src/grav/main.py
+++ b/src/grav/main.py
@@ -7,6 +7,7 @@ def main():
     The primary entrypoint for this project, and one that can be used in the
     `console_scripts` directive in setup.py.
     """
+    # future work: cli args parsing and --help
     tests = TestLoader().loadTestsFromModule(grav.test)
     # verbosity 2 is enough to show all tests, per:
     # https://github.com/python/cpython/blob/ecb035cd14c11521276343397151929a94018a22/Lib/unittest/runner.py#L40

--- a/src/grav/main.py
+++ b/src/grav/main.py
@@ -1,0 +1,20 @@
+from unittest import TestLoader, TextTestRunner
+import grav.test
+
+
+def main():
+    """
+    The primary entrypoint for this project, and one that can be used in the
+    `console_scripts` directive in setup.py.
+    """
+    tests = TestLoader().loadTestsFromModule(grav.test)
+    # verbosity 2 is enough to show all tests, per:
+    # https://github.com/python/cpython/blob/ecb035cd14c11521276343397151929a94018a22/Lib/unittest/runner.py#L40
+    # more doesn't seem to do anything -- wdella 2019-10
+    result = TextTestRunner(verbosity=2).run(tests)
+    if not result.wasSuccessful():
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/grav/test.py
+++ b/src/grav/test.py
@@ -13,6 +13,7 @@ if it runs to completion.  This is important for idempotency.
 import os
 import re
 from pkg_resources import resource_filename
+from unittest import TestCase
 
 from grav.client import demux_logs, DockerClient
 
@@ -108,6 +109,24 @@ def teardown(client, container_id, image_id):
     resp = client.request("DELETE", delete_path)
     resp.read()  # TODO: have this handled by the client
     assert resp.status == 200  # why isn't this 204 like the other api endpoints?
+
+
+class ContainerStartStopLogTest(TestCase):
+    """
+    Execercise start, stop and logs on a single docker container.
+    """
+
+    def setUp(self):
+        client, image_id, container_id, = setup()
+        self.client = client
+        self.image_id = image_id
+        self.container_id = container_id
+
+    def test_start_stop_logs(self):
+        test(self.client, self.container_id)
+
+    def tearDown(self):
+        teardown(self.client, self.container_id, self.image_id)
 
 
 if __name__ == "__main__":

--- a/src/grav/test.py
+++ b/src/grav/test.py
@@ -47,6 +47,9 @@ class ContainerStartStopLogTest(TestCase):
 
         assert resp.status == 200
         json = resp.json()
+        # N.B. I haven't found a way to avoid this regex parsing.  I'd love it
+        # if this api returned a proper json map I could parse the ID out of
+        # -- wdella 2019-10
         match = re.match(r"Loaded image ID: (sha256:[\da-f]{64})", json['stream'])
         image_id = match.group(1)
 

--- a/src/grav/test.py
+++ b/src/grav/test.py
@@ -102,10 +102,14 @@ class ContainerStartStopLogTest(DockerApiTest):
         stdout, stderr = demux_logs(resp.read())
 
         # validate
+        # future work: check return code?
+
+        # stderr first, as in this case we'd expect stdout to be corrupt, and
+        # the stderr content will likely be useful for triage.
+        self.assertEqual(stderr, "")
         stdout_lines = stdout.splitlines()
         self.assertEqual(stdout_lines[0], "Hello Gravitational!")
         self.assertEqual(stdout_lines[-1], "Terminated. Bye!")
-        self.assertEqual(stderr, "")
 
     def tearDown(self):
         client = self.client

--- a/src/grav/test.py
+++ b/src/grav/test.py
@@ -42,8 +42,14 @@ class ContainerStartStopLogTest(DockerApiTest):
         # we only run the teardown for image & client, and skip container
         # teardown since it was never set up.
         #
+        # Similarly, if the code knows which part of the setup/teadown fails,
+        # it could chain errors to poinpoint which resources are dangling,
+        # and probably need to be cleaned up by hand.
+        #
         # That is more effort than this sample merits imo, so setup/teardown
-        # are all in one. -- wdella 2019-10
+        # are all in one, with no effort to pinpoint which resources may
+        # leak in the case of failure during setup/teardown.
+        # -- wdella 2019-10
         client = DockerClient("/var/run/docker.sock")
 
         # load image from tar, get image id

--- a/src/grav/test.py
+++ b/src/grav/test.py
@@ -24,37 +24,13 @@ Unittest is what's available and does the trick.
 import os
 import re
 from pkg_resources import resource_filename
-from unittest import TestCase
 
 from grav.client import demux_logs, DockerClient
+from grav.harness import DockerApiTest, assert_status
 
 
-class HttpStatusError(Exception):
-    pass
-
-
-def assert_status(response, expected):
-    # Not a unittest assert, as this is used in setup & teardown
-    # future work: validate argument types
-    if response.status != expected:
-        # future work: consider the case body isn't text or
-        # should be truncated... also prettyprinting
-        msg = "{} returned http status {} instead of expected {}.\nBody:\n{}"\
-            .format(response.request, response.status, expected, response.body)
-        raise HttpStatusError(msg)
-
-
-class ContainerStartStopLogTest(TestCase):
-    """
-    Execercise start, stop and logs on a single docker container.
-    """
-
-    def assertStatus(self, response, expected):
-        # camelCased for consistency with unittest assert/fail methods
-        try:
-            assert_status(response, expected)
-        except HttpStatusError as e:
-            self.failureException(str(e))
+class ContainerStartStopLogTest(DockerApiTest):
+    """Execercise start, stop and logs on a single docker container."""
 
     def setUp(self):
         # If this were real, I'd pass these magic strings stattered through

--- a/src/grav/test.py
+++ b/src/grav/test.py
@@ -11,6 +11,15 @@ The tearDown() function attempts to unwind any dangling resources
 from setUp() and test_start_stop_logs(). Ideally leaving a clean
 test enviromnent if it runs to completion.  This is important for
 idempotency.
+
+My choice of unittest as a harness is not because I like the framework.
+I find its OO heavy syntax and camelcasing rather heavyweight and
+java-esque.  I much prefer light weight imperative pytest style syntax.
+However I didn't want to introduce 3rd party dependencies and writing
+a minimal pytest clone was not likely to be worth the effort -- maybe
+an extra 100-150 LoC, and rather dynamic/introspecitve code at that.
+
+Unittest is what's available and does the trick.
 """
 import os
 import re

--- a/src/grav/test.py
+++ b/src/grav/test.py
@@ -1,14 +1,16 @@
 """
 This file contains meat of the Gravitational QA coding challenge.
 
-The test() function performs the test as requested in the challenge.
+The test_start_stop_logs() method performs the test as requested
+in the challenge.
 
-The setup() function does all the provisioning necessary to go from:
+The setUp() method does all the provisioning necessary to go from:
   "package is installed" -> "start/stop/logs a wellknown container"
 
-The teardown() function attempts to unwind any dangling resources
-from setup() and test(). Ideally leaving a clean test enviromnent
-if it runs to completion.  This is important for idempotency.
+The tearDown() function attempts to unwind any dangling resources
+from setUp() and test_start_stop_logs(). Ideally leaving a clean
+test enviromnent if it runs to completion.  This is important for
+idempotency.
 """
 import os
 import re
@@ -18,118 +20,105 @@ from unittest import TestCase
 from grav.client import demux_logs, DockerClient
 
 
-def setup():
-    # If this were real, I'd pass these magic strings stattered through
-    # file as params and have them loaded from a config.
-    image_tar = resource_filename(__name__, "wellknown.tar")
-
-    # It'd be better to nest client, image, container setup/teardown
-    # so that in the case client & image succeed but container fails
-    # we only run the teardown for image & client, and skip container
-    # teardown since it was never set up.
-    #
-    # That is more effort than this sample merits imo, so setup/teardown
-    # are all in one. -- wdella 2019-10
-    client = DockerClient("/var/run/docker.sock")
-
-    # load image from tar, get image id
-    with open(image_tar, 'rb') as fh:
-        size = os.stat(image_tar).st_size
-        headers = {'Content-Type': 'application/tar', 'Content-Length': size}
-        resp = client.post("/images/load?fromSrc=-", body=fh, headers=headers)
-
-    assert resp.status == 200
-    json = resp.json()
-    match = re.match(r"Loaded image ID: (sha256:[\da-f]{64})", json['stream'])
-    image_id = match.group(1)
-
-    # create container, get container id
-    data = {"Image": image_id}
-    headers = {"Content-Type": "application/json"}
-    resp = client.post("/containers/create", body=data, headers=headers)
-    assert resp.status == 201
-    json = resp.json()
-    container_id = json['Id']
-
-    return client, image_id, container_id
-
-
-def test(client, container_id):
-    # start
-    start_path = "/containers/%s/start" % container_id
-    resp = client.post(start_path)
-    resp.read()  # TODO: have this handled by the client
-    assert resp.status == 204
-
-    # stop
-    stop_path = "/containers/%s/stop" % container_id
-    resp = client.post(stop_path)
-    resp.read()  # TODO: have this handled by the client
-    assert resp.status == 204
-
-    # logs
-    logs_path = "/containers/%s/logs" % container_id
-    logs_path += "?stdout=true&stderr=true"
-    resp = client.get(logs_path)
-    assert resp.status == 200
-    # logs doesn't return json, but a multiplexed stream
-    stdout, stderr = demux_logs(resp.read())
-
-    # validate
-    lines = stdout.splitlines()
-    assert lines[0] == "Hello Gravitational!"
-    assert lines[-1] == "Terminated. Bye!"
-    assert stderr == ""
-
-
-def teardown(client, container_id, image_id):
-    # if the test dies partway through, the container may
-    # still be running, and should be stopped
-    inspect_path = "/containers/%s/json" % container_id
-    resp = client.get(inspect_path)
-    assert resp.status == 200
-    json = resp.json()
-    state = json["State"]
-    running = state["Running"]
-    if running:
-        # stop
-        stop_path = "/containers/%s/stop" % container_id
-        resp = client.post(stop_path)
-        resp.read()  # TODO: have this handled by the client
-        assert resp.status == 204
-
-    # delete container
-    delete_path = "/containers/" + container_id
-    resp = client.request("DELETE", delete_path)
-    resp.read()  # TODO: have this handled by the client
-    assert resp.status == 204
-
-    # delete image
-    delete_path = "/images/" + image_id
-    resp = client.request("DELETE", delete_path)
-    resp.read()  # TODO: have this handled by the client
-    assert resp.status == 200  # why isn't this 204 like the other api endpoints?
-
-
 class ContainerStartStopLogTest(TestCase):
     """
     Execercise start, stop and logs on a single docker container.
     """
 
     def setUp(self):
-        client, image_id, container_id, = setup()
+        # If this were real, I'd pass these magic strings stattered through
+        # file as params and have them loaded from a config.
+        image_tar = resource_filename(__name__, "wellknown.tar")
+
+        # It'd be better to nest client, image, container setup/teardown
+        # so that in the case client & image succeed but container fails
+        # we only run the teardown for image & client, and skip container
+        # teardown since it was never set up.
+        #
+        # That is more effort than this sample merits imo, so setup/teardown
+        # are all in one. -- wdella 2019-10
+        client = DockerClient("/var/run/docker.sock")
+
+        # load image from tar, get image id
+        with open(image_tar, 'rb') as fh:
+            size = os.stat(image_tar).st_size
+            headers = {'Content-Type': 'application/tar', 'Content-Length': size}
+            resp = client.post("/images/load?fromSrc=-", body=fh, headers=headers)
+
+        assert resp.status == 200
+        json = resp.json()
+        match = re.match(r"Loaded image ID: (sha256:[\da-f]{64})", json['stream'])
+        image_id = match.group(1)
+
+        # create container, get container id
+        data = {"Image": image_id}
+        headers = {"Content-Type": "application/json"}
+        resp = client.post("/containers/create", body=data, headers=headers)
+        assert resp.status == 201
+        json = resp.json()
+        container_id = json['Id']
+
         self.client = client
         self.image_id = image_id
         self.container_id = container_id
 
     def test_start_stop_logs(self):
-        test(self.client, self.container_id)
+        container_id = self.container_id
+        client = self.client
+        # start
+        start_path = "/containers/%s/start" % container_id
+        resp = client.post(start_path)
+        resp.read()  # TODO: have this handled by the client
+        assert resp.status == 204
+
+        # stop
+        stop_path = "/containers/%s/stop" % container_id
+        resp = client.post(stop_path)
+        resp.read()  # TODO: have this handled by the client
+        assert resp.status == 204
+
+        # logs
+        logs_path = "/containers/%s/logs" % container_id
+        logs_path += "?stdout=true&stderr=true"
+        resp = client.get(logs_path)
+        assert resp.status == 200
+        # logs doesn't return json, but a multiplexed stream
+        stdout, stderr = demux_logs(resp.read())
+
+        # validate
+        lines = stdout.splitlines()
+        assert lines[0] == "Hello Gravitational!"
+        assert lines[-1] == "Terminated. Bye!"
+        assert stderr == ""
 
     def tearDown(self):
-        teardown(self.client, self.container_id, self.image_id)
+        client = self.client
+        container_id = self.container_id
+        image_id = self.image_id
 
+        # if the test dies partway through, the container may
+        # still be running, and should be stopped
+        inspect_path = "/containers/%s/json" % container_id
+        resp = client.get(inspect_path)
+        assert resp.status == 200
+        json = resp.json()
+        state = json["State"]
+        running = state["Running"]
+        if running:
+            # stop
+            stop_path = "/containers/%s/stop" % container_id
+            resp = client.post(stop_path)
+            resp.read()  # TODO: have this handled by the client
+            assert resp.status == 204
 
-if __name__ == "__main__":
-    client, image_id, container_id = setup()
-    test(client, container_id)
-    teardown(client, container_id, image_id)
+        # delete container
+        delete_path = "/containers/" + container_id
+        resp = client.request("DELETE", delete_path)
+        resp.read()  # TODO: have this handled by the client
+        assert resp.status == 204
+
+        # delete image
+        delete_path = "/images/" + image_id
+        resp = client.request("DELETE", delete_path)
+        resp.read()  # TODO: have this handled by the client
+        assert resp.status == 200  # why isn't this 204 like the other api endpoints?

--- a/src/grav/test.py
+++ b/src/grav/test.py
@@ -85,7 +85,7 @@ class ContainerStartStopLogTest(DockerApiTest):
         start_path = "/containers/%s/start" % container_id
         resp = client.post(start_path)
         resp.read()  # TODO: have this handled by the client
-        self.assertStatus(resp, 201)
+        self.assertStatus(resp, 204)
 
         # stop
         stop_path = "/containers/%s/stop" % container_id


### PR DESCRIPTION
This PR addresses some previous feedback (#7 and #8) and cleans up a bunch of 'it works but is fragile'.  Now we have nice error messages, and teardown even if the test fails.

The changes in `src/grav/test.py` look big because indentation changes but they're actually small (`assert` changes, unittest integration, and some comments)

Testing done:
```
# without docker running

(venv) vagrant@ubuntu-bionic:/vagrant$ python3 src/grav/main.py
test_start_stop_logs (grav.test.ContainerStartStopLogTest) ... ERROR

======================================================================
ERROR: test_start_stop_logs (grav.test.ContainerStartStopLogTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vagrant/src/grav/client.py", line 99, in __init__
    self.conn.connect()
  File "/vagrant/src/grav/client.py", line 78, in connect
    sock.connect(self.socket_path)
ConnectionRefusedError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/vagrant/src/grav/test.py", line 47, in setUp
    client = DockerClient("/var/run/docker.sock")
  File "/vagrant/src/grav/client.py", line 102, in __init__
    raise DockerClientError(msg) from e
grav.client.DockerClientError: Unable to connect to '/var/run/docker.sock'. Is the docker daemon running?

----------------------------------------------------------------------
Ran 1 test in 0.007s

FAILED (errors=1)


# killing docker part way through setup

(venv) vagrant@ubuntu-bionic:/vagrant$ python3 src/grav/main.py
test_start_stop_logs (grav.test.ContainerStartStopLogTest) ... ERROR

======================================================================
ERROR: test_start_stop_logs (grav.test.ContainerStartStopLogTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vagrant/src/grav/client.py", line 114, in request
    self.conn.request(verb, path, body=body, headers=headers)
  File "/usr/lib/python3.6/http/client.py", line 1254, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.6/http/client.py", line 1300, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.6/http/client.py", line 1249, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.6/http/client.py", line 1036, in _send_output
    self.send(msg)
  File "/usr/lib/python3.6/http/client.py", line 996, in send
    self.sock.sendall(data)
BrokenPipeError: [Errno 32] Broken pipe

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/vagrant/src/grav/test.py", line 68, in setUp
    resp = client.post("/containers/create", body=data, headers=headers)
  File "/vagrant/src/grav/client.py", line 108, in post
    return self.request("POST", path, body=body, headers=headers)
  File "/vagrant/src/grav/client.py", line 119, in request
    raise DockerClientError(msg) from e
grav.client.DockerClientError: Failure during 'POST /containers/create request to '/var/run/docker.sock'

# a forced failure:

(venv) vagrant@ubuntu-bionic:/vagrant$ python3 src/grav/main.py
test_start_stop_logs (grav.test.ContainerStartStopLogTest) ... FAIL

======================================================================
FAIL: test_start_stop_logs (grav.test.ContainerStartStopLogTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vagrant/src/grav/test.py", line 89, in test_start_stop_logs
    self.assertStatus(resp, 400)
  File "/vagrant/src/grav/harness.py", line 29, in assertStatus
    raise self.failureException(e) from None
AssertionError: POST /containers/5b8c4dfc5d049336a244d61507ed997cb7f4ebb6132a5b39fab3bd6ced4b514a/start returned http status 204 instead of expected 400.
Body:
b''

----------------------------------------------------------------------
Ran 1 test in 3.542s

FAILED (failures=1)
(venv) vagrant@ubuntu-bionic:/vagrant$ docker container ls -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
```
```
